### PR TITLE
blkzone: add open/close/finish commands

### DIFF
--- a/sys-utils/blkzone.8
+++ b/sys-utils/blkzone.8
@@ -55,10 +55,31 @@ x?:Reserved conditions (should not be reported)
 The command \fBblkzone reset\fP is used to reset one or more zones. Unlike
 .BR sg_reset_wp (8),
 this command operates from the block layer and can reset a range of zones.
+
+.SS open
+The command \fBblkzone open\fP is used to explicitly open one or more zones.
+Unlike
+.BR sg_zone (8),
+open action, this command operates from the block layer and can open a range
+of zones.
+
+.SS close
+The command \fBblkzone close\fP is used to close one or more zones. Unlike
+.BR sg_zone (8),
+close action, this command operates from the block layer and can close a range
+of zones.
+
+.SS finish
+The command \fBblkzone finish\fP is used to finish (transition to full condition)
+one or more zones. Unlike
+.BR sg_zone (8),
+finish action, this command operates from the block layer and can finish a range
+of zones.
+
 .PP
-By default, the command will operate from the zone at device
-sector 0 and reset all zones. Options may be used to modify this behavior
-as well as specify the operation to be performed on the zone, as explained below.
+By default, the reset, open, close and finish commands will operate from the zone
+at device sector 0 and operate on all zones. Options may be used to modify this
+behavior as explained below.
 
 .SH OPTIONS
 The


### PR DESCRIPTION
Introduce blkzone open, close and finish commands, issuing BLKOPENZONE,
BLKCLOSEZONE and BLKFINISHZONE ioctl commands to open, close or finish
a range of zones of a zoned block device.

Since these three commands are similar to the existing zone reset
command, the existing zone reset command implementation is changed into
the generic blkzone_action() internal handler function for processing
all zone actions.

The BLKOPENZONE, BLKCLOSEZONE and BLKFINISHZONE ioctl commands codes are
defined in linux/blkzoned.h starting with kernel version 5.5. To ensure
that the blkzone utility compiles even with older blkzoned.h kernel
header versions, these ioctl commands are internally defined if the
blkzoned.h header definition is not present. Execution of these commands
on kernels older than 5.5 will result in a -ENOTTY error (missing
ioctl).

Signed-off-by: Aravind Ramesh <Aravind.Ramesh@wdc.com>
Signed-off-by: Damien Le Moal <damien.lemoal@wdc.com>
Tested-by: Hans Holmberg <Hans.Holmberg@wdc.com>
Reviewed-by: Hans Holmberg <Hans.Holmberg@wdc.com>