### PR TITLE
fstrim: rename --quite to --quite-unsupported

### DIFF
--- a/bash-completion/fstrim
+++ b/bash-completion/fstrim
@@ -17,7 +17,7 @@ _fstrim_module()
 		-*)
 			OPTS="--all
 				--fstab
-				--quiet
+				--quiet-unsupported
 				--offset
 				--length
 				--minimum

--- a/sys-utils/fstrim.8
+++ b/sys-utils/fstrim.8
@@ -99,9 +99,10 @@ LVM setup, etc.  These reductions would not be reflected in fstrim_range.len
 .B \-\-length
 option).
 .TP
-.B \-\-quiet
-Suppress trim operation (ioctl) error messages.  This option is meant to be used in systemd service
-file or in cron scripts to hide warnings that are result of known problems,
+.B \-\-quiet\-unsupported
+Suppress error messages if trim operation (ioctl) is unsupported.  This option
+is meant to be used in systemd service file or in cron scripts to hide warnings
+that are result of known problems,
 such as NTFS driver
 reporting
 .I Bad file descriptor

--- a/sys-utils/fstrim.service.in
+++ b/sys-utils/fstrim.service.in
@@ -5,7 +5,7 @@ ConditionVirtualization=!container
 
 [Service]
 Type=oneshot
-ExecStart=@sbindir@/fstrim --fstab --verbose --quiet
+ExecStart=@sbindir@/fstrim --fstab --verbose --quiet-unsupported
 PrivateDevices=no
 PrivateNetwork=yes
 PrivateUsers=no


### PR DESCRIPTION
We use --verbose together with --quite in service files. It seems
confusing, let's make the option more descriptive.

Addresses: https://github.com/karelzak/util-linux/issues/1001
Signed-off-by: Karel Zak <kzak@redhat.com>