### PR TITLE
blkzone: deny destructive ioctls on busy blockdev

### DIFF
--- a/sys-utils/blkzone.c
+++ b/sys-utils/blkzone.c
@@ -301,7 +301,7 @@ static int blkzone_action(struct blkzone_control *ctl)
 	if (!zonesize)
 		errx(EXIT_FAILURE, _("%s: unable to determine zone size"), ctl->devname);
 
-	fd = init_device(ctl, O_WRONLY);
+	fd = init_device(ctl, O_WRONLY | O_EXCL);
 
 	if (ctl->offset & (zonesize - 1))
 		errx(EXIT_FAILURE, _("%s: offset %" PRIu64 " is not aligned "


### PR DESCRIPTION
If a user submits a zone management ioctl from user-space, like a zone
reset and a file-system (like zonefs or f2fs) is mounted on the zoned
block device, the zone will get reset and the file-system's cached value
of the zone's write-pointer becomes invalid.

Subsequent writes to this zone from the file-system will result in
unaligned writes and the drive will error out.

Open the block device file in exclusive mode for submitting these ioctls.
If a file-system is mounted the kernel will return -EBUSY and we can't
continue issuing the ioctl.

[kzak@redhat.com: - remove unnecessary error message]

Reported-by: Coly Li <colyli@suse.de>
Cc: Damien Le Moal <Damien.LeMoal@wdc.com>
Signed-off-by: Johannes Thumshirn <johannes.thumshirn@wdc.com>
Signed-off-by: Karel Zak <kzak@redhat.com>