### PR TITLE
Manual pages: blockdev.8, sfdisk.8: typo fixes

### DIFF
--- a/disk-utils/blockdev.8
+++ b/disk-utils/blockdev.8
@@ -48,7 +48,7 @@ Get alignment offset.
 .IP "\fB\-\-getbsz\fP"
 Print the blocksize in bytes.
 This size does not describe device topology.  It's
-the size used internally by ithe kernel and it may be modified (for example) by
+the size used internally by the kernel and it may be modified (for example) by
 filesystem driver on mount.
 .IP "\fB\-\-getdiscardzeroes\fP"
 Get discard zeroes support status.

--- a/disk-utils/sfdisk.8
+++ b/disk-utils/sfdisk.8
@@ -600,7 +600,7 @@ The welcome message.
 
 .SH ENVIRONMENT
 .IP SFDISK_DEBUG=all
-enablescw
+enables
 .B sfdisk
 debug output.
 .IP LIBFDISK_DEBUG=all


### PR DESCRIPTION
Fix a couple of typos that I introduced.

Signed-off-by: Michael Kerrisk (man-pages) <mtk.manpages@gmail.com>